### PR TITLE
Wait to initialize JLD datasets until have 1 valid mon object

### DIFF
--- a/test/driver.jl
+++ b/test/driver.jl
@@ -2,7 +2,8 @@ driverprocs = addprocs(2)
 
 # Work around julia #3674
 using Images, JLD, Base.Test
-using BlockRegistrationScheduler, RegisterDriver, RegisterWorkerShell
+using BlockRegistration, BlockRegistrationScheduler
+using RegisterDriver, RegisterWorkerShell
 @sync for p in driverprocs
     @spawnat p eval(quote
         using Images, JLD, Base.Test


### PR DESCRIPTION
This circumvents the need for users to specify the size of output arrays.
