### PR TITLE
add 3d rigid registration test

### DIFF
--- a/test/rigid.jl
+++ b/test/rigid.jl
@@ -3,6 +3,7 @@ using BlockRegistration
 using BlockRegistrationScheduler, RegisterDriver, RegisterWorkerShell, RegisterWorkerRigid
 using Base.Test
 
+#2d
 fixed = testimage("cameraman")
 tfm = tformrotate(pi/12)
 moving = transform(fixed, tfm)
@@ -14,5 +15,28 @@ mon[:mismatch] = 0.0
 mon = driver(alg, moving, mon)
 ptfm = mon[:tform]*tfm
 @test_approx_eq_eps ptfm.scalefwd eye(2) 0.01
+@test all(abs(ptfm.offset) .< 0.2)
+@test mon[:mismatch] < 0.001
+
+
+#3d
+fixed = testimage("cameraman")
+fixed0 = deepcopy(fixed)
+fixed = zeros(size(fixed)...,20)
+for i = 1:20
+    fixed[:,:,i] = data(fixed0)
+end
+fixed = copyproperties(fixed0, fixed)
+fixed["spatialorder"] = ["x"; "l"; "z"]
+tfm = tformrotate([0;0;1;], pi/12)
+moving = transform(fixed, tfm)
+
+alg = Rigid(fixed, pat=false, print_level=5)
+mon = monitor(alg, ())
+mon[:tform] = nothing
+mon[:mismatch] = 0.0
+mon = driver(alg, moving, mon)
+ptfm = mon[:tform]*tfm
+@test_approx_eq_eps ptfm.scalefwd eye(3) 0.01
 @test all(abs(ptfm.offset) .< 0.2)
 @test mon[:mismatch] < 0.001


### PR DESCRIPTION
Added a 3 dimensional test of rigid registration.  The test currently fails, highlighting a problem with optimization of 3d transformations.  I'm trying to track down the problem now, but wanted to get this out in case it takes me a while.  The Ipopt optimization of the affine transformation seems to be stuck evaluating the same point over and over.
