### PR TITLE
Centralize PreprocessSNF

### DIFF
--- a/src/RegisterWorkerAperturesMismatch.jl
+++ b/src/RegisterWorkerAperturesMismatch.jl
@@ -5,11 +5,11 @@ module RegisterWorkerAperturesMismatch
 using Images, AffineTransforms, Interpolations, FixedSizeArrays
 using RegisterCore, RegisterDeformation, RegisterFit, RegisterPenalty, RegisterOptimize
 # Note: RegisterMismatch/RegisterMismatchCuda is selected below
-using RegisterWorkerShell
+using RegisterWorkerShell, RegisterDriver
 
 import RegisterWorkerShell: worker, init!, close!
 
-export AperturesMismatch, PreprocessSNF, monitor, monitor!, worker, workerpid
+export AperturesMismatch, monitor, monitor!, worker, workerpid
 
 type AperturesMismatch{A<:AbstractArray,T,K,N} <: AbstractWorker
     fixed::A
@@ -166,45 +166,6 @@ function _copy_mm!(dest, src, colons, R)
         dest[colons..., I] = mm.data.coefs
     end
     dest
-end
-
-
-"""
-`pp = PreprocessSNF(bias, sigmalp, sigmahp)` constructs an object that
-can be used to pre-process an image as `pp(img)`. The "SNF" part of
-the name means "shot-noise filtered," meaning that this preprocessor
-is specifically designed for situations in which you are dominated by
-shot noise (i.e., from photon-counting statistics).
-
-The processing is of the form
-```
-    imgout = bandpass(√max(0,img-bias))
-```
-i.e., the image is bias-subtracted, square-root transformed (to turn
-shot noise into constant variance), and then band-pass filtered using
-Gaussian filters of width `sigmalp` (for the low-pass) and `sigmahp`
-(for the high-pass).
-"""
-type PreprocessSNF  # Shot-noise filtered
-    bias::Float32
-    sigmalp::Vector{Float32}
-    sigmahp::Vector{Float32}
-end
-# PreprocessSNF(bias::T, sigmalp, sigmahp) = PreprocessSNF{T}(bias, T[sigmalp...], T[sigmahp...])
-
-function Base.call(pp::PreprocessSNF, A::AbstractArray)
-    Af = sqrt_subtract_bias(A, pp.bias)
-    imfilter_gaussian(highpass(Af, pp.sigmahp), pp.sigmalp)
-end
-
-function sqrt_subtract_bias(A, bias)
-#    T = typeof(sqrt(one(promote_type(eltype(A), typeof(bias)))))
-    T = Float32
-    out = Array(T, size(A))
-    for I in eachindex(A)
-        @inbounds out[I] = sqrt(max(zero(T), convert(T, A[I]) - bias))
-    end
-    out
 end
 
 end # module


### PR DESCRIPTION
Previously, this was defined (and exported) from two separate modules, which led to a warning.
