### PR TITLE
Re: Cuda type error fix

### DIFF
--- a/src/RegisterWorkerAperturesMismatch.jl
+++ b/src/RegisterWorkerAperturesMismatch.jl
@@ -123,7 +123,8 @@ function AperturesMismatch{K,N}(fixed, knots::NTuple{N,K}, maxshift, preprocess=
 end
 
 function worker(algorithm::AperturesMismatch, img, tindex, mon)
-    moving0 = timedim(img) == 0 ? img : slice(img, "t", tindex)
+#    moving0 = timedim(img) == 0 ? img : slice(img, "t", tindex)
+    moving0 = timedim(img) == 0 ? img : data(getindexim(img, "t", tindex))
     moving = algorithm.preprocess(moving0)
     gridsize = map(length, algorithm.knots)
     use_cuda = algorithm.dev >= 0


### PR DESCRIPTION
I tried to register `SubArray` data type. Type error occurred due to the type mismatch between `moving` and `fixed`. After `slice` an image in the code, the data type remained as SubArray, which does not match with the type of `fixed`.
I modified the code. Now, the data type of `moving` becomes `Array`. This matches with that of `fixed`
There might be a better way; changing the data type of `fixed` did not work on my hands
